### PR TITLE
WPD Interop DLLの型埋め込み対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@ RICOH THETA Sなどのカメラを操作することができます。
 
 #### 使い方(概要)
 1. MtpCommandのインスタンスを生成します。  
-2. MtpCommandのGetDeviceIds()でPCに接続されているデバイスIDの一覧を取得します。  
-3. MtpCommandのOpen()でデバイスに接続します。  
-4. MtpCommandのExecute()でMTP通信を実行します。  
-5. MtpCommandのClose()でデバイスを切断します。  
+1. MtpCommandのGetDeviceIds()でPCに接続されているデバイスIDの一覧を取得します。  
+1. MtpCommandのOpen()でデバイスに接続します。  
+1. MtpCommandのExecute()でMTP通信を実行します。  
+1. MtpCommandのClose()でデバイスを切断します。  
 
 #### 注意点
-1. 本ライブラリを使用する時は、PortableDeviceAplLibとPortableDeviceTypesLibが必要です。参照に追加してください。また、左記２つのライブラリの相互運用型の埋め込みをFalseにする必要があります。なぜはかわかりません。知っている方教えてください。
-2. いろんなところで予期せぬエラーが発生すると思います。ご使用は計画的かつ慎重に。  
-2. OpenSessionとCloseSessionはWindowsが自動的に行っているようです(未確認)  
-3. 64bitだとダメかもしれません(手元にないので不明。。)  
+1. いろんなところで予期せぬエラーが発生すると思います。ご使用は計画的かつ慎重に。  
+1. OpenSessionとCloseSessionはWindowsが自動的に行っているようです(未確認)   
 
 #### その他
 実装には下記サイトをものすご～く参考にさせていただきました。  

--- a/WpdMtpLib/MtpCommand.cs
+++ b/WpdMtpLib/MtpCommand.cs
@@ -164,13 +164,13 @@ namespace WpdMtpLib
         {
             if (device != null) { return; }
             device = new PortableDevice();
-            IPortableDeviceValues clientInfo = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues clientInfo = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             device.Open(deviceId, clientInfo);
             Marshal.ReleaseComObject(clientInfo);
 
             // eventを受信できるようにする
             WpdEvent wpdEvent = new WpdEvent(this);
-            IPortableDeviceValues eventParameter = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues eventParameter = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             device.Advise(0, wpdEvent, eventParameter, out eventCookie);
         }
 

--- a/WpdMtpLib/MtpOperation.cs
+++ b/WpdMtpLib/MtpOperation.cs
@@ -122,7 +122,7 @@ namespace WpdMtpLib
             if (responseCode == 0x2001)
             {
                 IPortableDevicePropVariantCollection resultValues
-                    = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollectionClass();
+                    = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollection();
                 spResults.GetIPortableDevicePropVariantCollectionValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_RESPONSE_PARAMS, out resultValues);
 
                 uint count = 1;
@@ -192,7 +192,7 @@ namespace WpdMtpLib
             {
                 // データ受信用のコマンドを構築する
                 bufferIn = new byte[size];
-                mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+                mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
                 mtpCommand.SetGuidValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_CATEGORY, ref WpdProperty.WPD_COMMAND_MTP_EXT_READ_DATA.fmtid);
                 mtpCommand.SetUnsignedIntegerValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_ID, WpdProperty.WPD_COMMAND_MTP_EXT_READ_DATA.pid);
                 mtpCommand.SetStringValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_TRANSFER_CONTEXT, context);
@@ -268,7 +268,7 @@ namespace WpdMtpLib
             Marshal.ReleaseComObject(spResults);
 
             // データ送信用のコマンドを構築する
-            mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             mtpCommand.SetGuidValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_CATEGORY, ref WpdProperty.WPD_COMMAND_MTP_EXT_WRITE_DATA.fmtid);
             mtpCommand.SetUnsignedIntegerValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_ID, WpdProperty.WPD_COMMAND_MTP_EXT_WRITE_DATA.pid);
             mtpCommand.SetStringValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_TRANSFER_CONTEXT, context);
@@ -303,7 +303,7 @@ namespace WpdMtpLib
         /// <returns></returns>
         private static void sendEndDataTransfer(PortableDevice device, string context, out uint responseCode, out uint[] responseParam)
         {
-            IPortableDeviceValues mtpEndDataTransfer = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues mtpEndDataTransfer = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             mtpEndDataTransfer.SetGuidValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_CATEGORY, ref WpdProperty.WPD_COMMAND_MTP_EXT_END_DATA_TRANSFER.fmtid);
             mtpEndDataTransfer.SetUnsignedIntegerValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_ID, WpdProperty.WPD_COMMAND_MTP_EXT_END_DATA_TRANSFER.pid);
             mtpEndDataTransfer.SetStringValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_TRANSFER_CONTEXT, context);
@@ -330,7 +330,7 @@ namespace WpdMtpLib
             if (responseCode == 0x2001)
             {
                 IPortableDevicePropVariantCollection resultValues
-                    = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollectionClass();
+                    = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollection();
                 spResults.GetIPortableDevicePropVariantCollectionValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_RESPONSE_PARAMS, out resultValues);
 
                 uint count = 1;
@@ -356,7 +356,7 @@ namespace WpdMtpLib
         /// <returns></returns>
         private static IPortableDeviceValues createMtpCommand(MtpOperationCode code, _tagpropertykey dataPhase)
         {
-            IPortableDeviceValues mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues mtpCommand = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             mtpCommand.SetGuidValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_CATEGORY, ref dataPhase.fmtid);
             mtpCommand.SetUnsignedIntegerValue(ref WpdProperty.WPD_PROPERTY_COMMON_COMMAND_ID, dataPhase.pid);
             mtpCommand.SetUnsignedIntegerValue(ref WpdProperty.WPD_PROPERTY_MTP_EXT_OPERATION_CODE, (uint)code);
@@ -372,7 +372,7 @@ namespace WpdMtpLib
         private static IPortableDevicePropVariantCollection createMtpCommandParameter(uint[] param)
         {
             IPortableDevicePropVariantCollection mtpCommandParameter
-                = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollectionClass();
+                = (IPortableDevicePropVariantCollection)new PortableDeviceTypesLib.PortableDevicePropVariantCollection();
             foreach (uint p in param)
             {
                 tag_inner_PROPVARIANT propValiant = createPropVariant(p);
@@ -391,7 +391,7 @@ namespace WpdMtpLib
         {
             tag_inner_PROPVARIANT propVariant = new tag_inner_PROPVARIANT();
 
-            IPortableDeviceValues pdValues = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues pdValues = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             pdValues.SetUnsignedIntegerValue(ref WpdProperty.WPD_OBJECT_ID, value);
             pdValues.GetValue(ref WpdProperty.WPD_OBJECT_ID, out propVariant);
             Marshal.ReleaseComObject(pdValues);
@@ -408,7 +408,7 @@ namespace WpdMtpLib
         {
             uint ret = 1;
 
-            IPortableDeviceValues pdValues = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValuesClass();
+            IPortableDeviceValues pdValues = (IPortableDeviceValues)new PortableDeviceTypesLib.PortableDeviceValues();
             pdValues.SetValue(ref WpdProperty.WPD_OBJECT_ID, ref value);
             pdValues.GetUnsignedIntegerValue(ref WpdProperty.WPD_OBJECT_ID, out ret);
             Marshal.ReleaseComObject(pdValues);

--- a/WpdMtpLib/WpdMtpLib.csproj
+++ b/WpdMtpLib/WpdMtpLib.csproj
@@ -71,7 +71,7 @@
       <Lcid>0</Lcid>
       <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* WpdMtpLib.dllにWPDのCOM型は埋め込んだのでInterop DLLは今後ユーザー側は忘れることが出来ます
  * READMEから注意書き外しました。64bitも問題無さそうなのでこちらもついでに。
* XxxClassという実装クラスを呼び出してはいけない様です。理由は・・・分かりません。英文読めばきっと分かるんだと思います。。
  * [c# - Interop type cannot be embedded - Stack Overflow](http://stackoverflow.com/questions/2483659/interop-type-cannot-be-embedded)
  * [VS 2010 compiler error: Interop type XXX cannot be embedded. Use the applicable interface instead. | Misha Shneerson](https://blogs.msdn.microsoft.com/mshneer/2009/12/07/vs-2010-compiler-error-interop-type-xxx-cannot-be-embedded-use-the-applicable-interface-instead/)