### PR TITLE
DeviceProtocolの取得対応

### DIFF
--- a/WpdMtpLib/MtpCommand.cs
+++ b/WpdMtpLib/MtpCommand.cs
@@ -97,6 +97,37 @@ namespace WpdMtpLib
         }
 
         /// <summary>
+        /// デバイスプロトコルを取得する
+        /// </summary>
+        /// <param name="deviceId">デバイスID</param>
+        public string GetDeviceProtocol(string deviceId)
+        {
+            PortableDeviceManager manager = new PortableDeviceManager();
+            string deviceProtocol = string.Empty;
+            try
+            {
+                Open(deviceId);
+                IPortableDeviceContent content;
+                IPortableDeviceProperties properties;
+                device.Content(out content);
+                content.Properties(out properties);
+                PortableDeviceApiLib.IPortableDeviceValues propertyValues;
+                properties.GetValues("DEVICE", null, out propertyValues);
+                propertyValues.GetStringValue(WpdProperty.WPD_DEVICE_PROTOCOL, out deviceProtocol);
+                if (Marshal.IsComObject(propertyValues)) { Marshal.ReleaseComObject(propertyValues); }
+                if (Marshal.IsComObject(properties)) { Marshal.ReleaseComObject(properties); }
+                if (Marshal.IsComObject(content)) { Marshal.ReleaseComObject(content); }
+                Close();
+            }
+            catch (Exception)
+            {
+                deviceProtocol = string.Empty;
+            }
+            Marshal.ReleaseComObject(manager);
+
+            return deviceProtocol;
+        }
+        /// <summary>
         /// デバイス種別を取得する
         /// </summary>
         /// <param name="deviceId">デバイスID</param>

--- a/WpdMtpLib/WpdProperty.cs
+++ b/WpdMtpLib/WpdProperty.cs
@@ -139,6 +139,11 @@ namespace WpdMtpLib
         /**************************************/
         /*               OTHER                */
         /**************************************/
+        public static _tagpropertykey WPD_DEVICE_PROTOCOL = new _tagpropertykey()
+        {
+            fmtid = new Guid(0x26D4979A, 0xE643, 0x4626, 0x9E, 0x2B, 0x73, 0x6D, 0xC0, 0xC9, 0x2F, 0xDC),
+            pid = 6
+        };
         public static _tagpropertykey WPD_DEVICE_TYPE = new _tagpropertykey()
         {
             fmtid = new Guid(0x26D4979A, 0xE643, 0x4626, 0x9E, 0x2B, 0x73, 0x6D, 0xC0, 0xC9, 0x2F, 0xDC),


### PR DESCRIPTION
* WPD_DEVICE_PROTOCOLに対応しました
* 各デバイスによって、"MTP: 1.0" "MTP: 1.1" "PTP: 1.0" "MSC:"等が取得されました
* 対応方法は先日のDeviceType(#10)とほぼ同じです