### PR TITLE
support DataType.STR for DevicePropDesc

### DIFF
--- a/WpdMtpLib/DevicePropDesc.cs
+++ b/WpdMtpLib/DevicePropDesc.cs
@@ -93,6 +93,13 @@ namespace WpdMtpLib
                         value[i] = BitConverter.ToUInt64(data, pos); pos += 8;
                     }
                     break;
+                case DataType.STR:
+                    value = new String[arraySize];
+                    for (int i = 0; i < arraySize; i++)
+                    {
+                        value[i] = Utils.GetString(data, ref pos);
+                    }
+                    break;
                 default:
                     break;
             }
@@ -149,6 +156,9 @@ namespace WpdMtpLib
                     break;
                 case DataType.UINT64:
                     value = BitConverter.ToUInt64(data, pos); pos += 8;
+                    break;
+                case DataType.STR:
+                    value = Utils.GetString(data, ref pos);
                     break;
                 default:
                     break;


### PR DESCRIPTION
WpdMtpLib::DevicePropDesc で DataType.STR 型のdevicePropをサポート