### PR TITLE
接続中にデバイスプロトコルまたはデバイス種別を取得すると切断してしまう不具合の修正

### DIFF
--- a/WpdMtpLib/MtpCommand.cs
+++ b/WpdMtpLib/MtpCommand.cs
@@ -129,7 +129,8 @@ namespace WpdMtpLib
             string deviceProtocol = string.Empty;
             try
             {
-                Open(deviceId);
+                var isOpened = IsOpened();
+                if (!isOpened) { Open(deviceId); }
                 IPortableDeviceContent content;
                 IPortableDeviceProperties properties;
                 device.Content(out content);
@@ -140,7 +141,7 @@ namespace WpdMtpLib
                 if (Marshal.IsComObject(propertyValues)) { Marshal.ReleaseComObject(propertyValues); }
                 if (Marshal.IsComObject(properties)) { Marshal.ReleaseComObject(properties); }
                 if (Marshal.IsComObject(content)) { Marshal.ReleaseComObject(content); }
-                Close();
+                if (!isOpened) { Close(); }
             }
             catch (Exception)
             {
@@ -159,7 +160,8 @@ namespace WpdMtpLib
             PortableDeviceManager manager = new PortableDeviceManager();
             uint deviceType = (uint)DeviceType.Unknown;
             try {
-                Open(deviceId);
+                var isOpened = IsOpened();
+                if (!isOpened) { Open(deviceId); }
                 IPortableDeviceContent content;
                 IPortableDeviceProperties properties;
                 device.Content(out content);
@@ -170,7 +172,7 @@ namespace WpdMtpLib
                 if (Marshal.IsComObject(propertyValues)) { Marshal.ReleaseComObject(propertyValues); }
                 if (Marshal.IsComObject(properties)) { Marshal.ReleaseComObject(properties); }
                 if (Marshal.IsComObject(content)) { Marshal.ReleaseComObject(content); }
-                Close();
+                if (!isOpened) { Close(); }
             }
             catch (Exception)
             {


### PR DESCRIPTION
### 不具合の現象・原因
* GetDeviceProtocol / GetDeviceType は接続しないと情報が取れないので一時的に接続していたが、既に接続済みの場合も呼び出し後切断していた
* 再接続時にこの現象は発生していたが、切断のタイミングによってはMTPが呼び出されるとCOM例外が発生した

### 対策
* 接続時にGetDeviceProtocol / GetDeviceTypeを呼び出してもCloseを行わない