### PR TITLE
読込データバッファー開放

### DIFF
--- a/WpdMtpLib/MtpOperation.cs
+++ b/WpdMtpLib/MtpOperation.cs
@@ -219,6 +219,7 @@ namespace WpdMtpLib
                 bufferOut = new byte[size];
                 Marshal.Copy(dataPtr, bufferOut, 0, bufferOut.Length);
                 Marshal.ReleaseComObject(spResults);
+                Marshal.FreeCoTaskMem(dataPtr);
             }
 
             // DataEndTransfer(レスポンス)を送信する


### PR DESCRIPTION
* データ読み込み付きオペレーション実行時にCOMが確保したバッファーデータの開放漏れを修正しました
  * 5000回ほど画像データを読み込んでメモリ100MB未満で安定するようになりました
* データ書き込み側はシャッタースピード設定を50000回ほどやりましたが30MB未満でリークしている様子は確認出来ませんでした