### PR TITLE
機能テスト向け対応とEncodePtpStringの不具合対応

### DIFF
--- a/WpdMtpLib/MtpCommand.cs
+++ b/WpdMtpLib/MtpCommand.cs
@@ -103,7 +103,7 @@ namespace WpdMtpLib
         /// デバイスの接続状況
         /// </summary>
         /// <returns></returns>
-        public bool IsOpened()
+        public virtual bool IsOpened()
         {
             return device != null;
         }

--- a/WpdMtpLib/Utils.cs
+++ b/WpdMtpLib/Utils.cs
@@ -53,9 +53,9 @@ namespace WpdMtpLib
         /// <returns></returns>
         public static byte[] EncodePtpString(string str)
         {
-            byte[] retVal = new byte[str.Length * 2 + 2];
+            byte[] retVal = new byte[(str.Length + 1) * 2 + 1];
             byte[] temp = Encoding.Unicode.GetBytes(str);
-            retVal[0] = (byte)str.Length;
+            retVal[0] = (byte)(str.Length + 1);
             Array.Copy(temp, 0, retVal, 1, temp.Length);
 
             return retVal;


### PR DESCRIPTION
* MtpCommand.IsOpened()をスタブ化可能な様にvirtual化
* Utils.EncodePtpString()で最後の"\0"も含めてエンコーディングするよう修正